### PR TITLE
Fix bug in component ID generation and allow components to modify the script element

### DIFF
--- a/ReactScriptLoader.js
+++ b/ReactScriptLoader.js
@@ -47,8 +47,8 @@ var ReactScriptLoader = {
 
 		var script = document.createElement('script');
 
-		if (typeof component.modifyScriptTag === 'function') {
-			component.modifyScriptTag(script);
+		if (typeof component.onScriptTagCreated === 'function') {
+			component.onScriptTagCreated(script);
 		}
 
 		script.src = scriptURL;


### PR DESCRIPTION
Couldn't figure out how to create two PRs out of a single branch, sorry.
The first commit stands alone and fixes a small bug.
The second two commits make it possible to modify the script DOM node before it is added to the DOM. The Dropbox dropins API needs a data attribute set on the script tag for example. The last two commits can be squashed into one.
