### PR TITLE
Allow for newer versions of node

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "main": "ReactScriptLoader.js",
   "engines": {
-    "node": "0.10.x"
+    "node": ">=0.10.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Is there any reason to restrict to only patch versions of the `0.10` releases of node? This allows for any newer versions of node to be used.