### PR TITLE
Fixing observer variable when use strict

### DIFF
--- a/ReactScriptLoader.js
+++ b/ReactScriptLoader.js
@@ -57,7 +57,7 @@ var ReactScriptLoader = {
 		var callObserverFuncAndRemoveObserver = function(func) {
 			var observers = scriptObservers[scriptURL];
 			for (var key in observers) {
-				observer = observers[key];
+				var observer = observers[key];
 				var removeObserver = func(observer);
 				if (removeObserver) {
 					delete scriptObservers[scriptURL][key];


### PR DESCRIPTION
This pull request fix the definition of variable `observer` at [ReactScriptLoader#L60](https://github.com/yariv/ReactScriptLoader/blob/master/ReactScriptLoader.js#L60).

When someone use the `strict mode` it's broken. I catch this error and make this pull request to fix it.

This PR solves #10 

